### PR TITLE
Removing "prepend" property from asset-map service for environment specific issue

### DIFF
--- a/addon/services/asset-map.js
+++ b/addon/services/asset-map.js
@@ -6,7 +6,6 @@ import { isNone } from '@ember/utils';
 export default Service.extend({
   enabled: false,
   assetMapHash: null,
-  prepend: '/',
 
   resolve(name) {
     const map = this.get('assetMapHash');
@@ -28,6 +27,6 @@ export default Service.extend({
       resolvedName = name;
     }
 
-    return this.get('prepend') + resolvedName;
+    return resolvedName;
   }
 });


### PR DESCRIPTION
-the service works on an ember-application without the property as well
-it works on an engine-app environment as well-tested it with an application and two engines and it switches themes as expected and also loads the default theme